### PR TITLE
Fixes for dnf-2.2.0 dbus-signals (fix #18)

### DIFF
--- a/dnfdragora/const.py
+++ b/dnfdragora/const.py
@@ -122,7 +122,8 @@ HISTORY_STATE_LABLES = {
     'Install': _('Installed packages'),
     'True-Install': _('Installed packages'),
     'Dep-Install': _('Installed for dependencies'),
-    'Reinstall': _('Reinstalled packages')}
+    'Reinstall': _('Reinstalled packages')
+}
 
 
 TRANSACTION_RESULT_TYPES = {
@@ -141,7 +142,10 @@ RPM_ACTIONS = {
     'erase': _("Removing: %s"),
     'obsolete': _("Obsoleting: %s"),
     'downgrade': _("Downgrading: %s"),
-    'verify': _("Verifying: %s"),
+    'verify': _("Verifying: %s")
+    'scriptlet': _("Running scriptlet: %s"),
+    'preptrans': _("Preparing transaction: %s"),
+    'posttrans': _("Post-transaction script: %s")
 }
 
 WIDGETS_INSENSITIVE = ["header_menu", "header_filters",

--- a/po/dnfdragora.pot
+++ b/po/dnfdragora.pot
@@ -20,9 +20,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: dnfdragora 0.xx\n"
+"Project-Id-Version: dnfdragora 1.00\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-20 18:52+0100\n"
+"POT-Creation-Date: 2017-03-30 15:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -239,79 +239,94 @@ msgstr ""
 msgid "Reinstalled packages"
 msgstr ""
 
-#: dnfdragora/const.py:129
+#: dnfdragora/const.py:130
 msgid "Installing"
 msgstr ""
 
-#: dnfdragora/const.py:130
+#: dnfdragora/const.py:131
 msgid "Updating"
 msgstr ""
 
-#: dnfdragora/const.py:131
+#: dnfdragora/const.py:132
 msgid "Removing"
 msgstr ""
 
-#: dnfdragora/const.py:132
+#: dnfdragora/const.py:133
 msgid "Downgrading"
 msgstr ""
 
-#: dnfdragora/const.py:133
+#: dnfdragora/const.py:134
 msgid "Replacing"
-msgstr ""
-
-#: dnfdragora/const.py:137
-#, python-format
-msgid "Updating: %s"
 msgstr ""
 
 #: dnfdragora/const.py:138
 #, python-format
-msgid "Installing: %s"
+msgid "Updating: %s"
 msgstr ""
 
 #: dnfdragora/const.py:139
 #, python-format
-msgid "Reinstalling: %s"
+msgid "Installing: %s"
 msgstr ""
 
 #: dnfdragora/const.py:140
 #, python-format
-msgid "Cleanup: %s"
+msgid "Reinstalling: %s"
 msgstr ""
 
 #: dnfdragora/const.py:141
 #, python-format
-msgid "Removing: %s"
+msgid "Cleanup: %s"
 msgstr ""
 
 #: dnfdragora/const.py:142
 #, python-format
-msgid "Obsoleting: %s"
+msgid "Removing: %s"
 msgstr ""
 
 #: dnfdragora/const.py:143
 #, python-format
-msgid "Downgrading: %s"
+msgid "Obsoleting: %s"
 msgstr ""
 
 #: dnfdragora/const.py:144
 #, python-format
+msgid "Downgrading: %s"
+msgstr ""
+
+#: dnfdragora/const.py:145
+#, python-format
 msgid "Verifying: %s"
 msgstr ""
 
-#: dnfdragora/const.py:154
+#: dnfdragora/const.py:146
+#, python-format
+msgid "Running scriptlet: %s"
+msgstr ""
+
+#: dnfdragora/const.py:147
+#, python-format
+msgid "Preparing transaction: %s"
+msgstr ""
+
+#: dnfdragora/const.py:148
+#, python-format
+msgid "Post-transaction script: %s"
+msgstr ""
+
+#: dnfdragora/const.py:158
 msgid "Bugfix"
 msgstr ""
 
-#: dnfdragora/const.py:155
+#: dnfdragora/const.py:159
 msgid "New Package"
 msgstr ""
 
-#: dnfdragora/const.py:156 dnfdragora/groupicons.py:404
+#: dnfdragora/const.py:160 dnfdragora/groupicons.py:404
 msgid "Security"
 msgstr ""
 
-#: dnfdragora/const.py:157
+#: dnfdragora/const.py:161
 msgid "Enhancement"
 msgstr ""
 
@@ -352,12 +367,12 @@ msgstr ""
 msgid "Repository Management"
 msgstr ""
 
-#: dnfdragora/dialogs.py:218
-msgid "Enabled"
-msgstr ""
-
 #: dnfdragora/dialogs.py:218 dnfdragora/ui.py:324
 msgid "Name"
+msgstr ""
+
+#: dnfdragora/dialogs.py:218
+msgid "Enabled"
 msgstr ""
 
 #: dnfdragora/dialogs.py:229 dnfdragora/ui.py:434
@@ -990,7 +1005,11 @@ msgid "Software Management"
 msgstr ""
 
 #: dnfdragora/ui.py:324
-msgid "Arch"
+msgid "Summary"
+msgstr ""
+
+#: dnfdragora/ui.py:324
+msgid "Version"
 msgstr ""
 
 #: dnfdragora/ui.py:324
@@ -998,11 +1017,7 @@ msgid "Release"
 msgstr ""
 
 #: dnfdragora/ui.py:324
-msgid "Summary"
-msgstr ""
-
-#: dnfdragora/ui.py:324
-msgid "Version"
+msgid "Arch"
 msgstr ""
 
 #: dnfdragora/ui.py:331
@@ -1135,12 +1150,12 @@ msgid "Not implemented yet"
 msgstr ""
 
 #: dnfdragora/ui.py:1075
-#, python-format
-msgid "Package %s cannot be removed"
+msgid "Protected package selected"
 msgstr ""
 
 #: dnfdragora/ui.py:1075
-msgid "Protected package selected"
+#, python-format
+msgid "Package %s cannot be removed"
 msgstr ""
 
 #: dnfdragora/ui.py:1151


### PR DESCRIPTION
DNF-2.2.0 introduced a new RPM-ACTION on DBus.  This PR adresses this and keeps backwards-compat with older versions of DNF.