### PR TITLE
Additional .desktop files matching desktop environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ install(FILES ${CMAKE_BINARY_DIR}/etc/dnfdragora.yaml DESTINATION ${CMAKE_INSTAL
 # Installing data files
 install(FILES ${CMAKE_SOURCE_DIR}/share/metainfo/org.mageia.dnfdragora.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/appdata)
 install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-gtk.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-qt.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-localinstall.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-localinstall-gtk.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-localinstall-qt.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 install(FILES ${CMAKE_SOURCE_DIR}/share/images/dnfdragora-logo.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps RENAME dnfdragora.png)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/share/images DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dnfdragora)

--- a/share/applications/org.mageia.dnfdragora-gtk.desktop
+++ b/share/applications/org.mageia.dnfdragora-gtk.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=dnfdragora
+GenericName=Install & Remove Software
+Icon=dnfdragora
+Exec=dnfdragora --gtk
+OnlyShowIn=Cinnamon;GNOME;LXDE;MATE;ROX;XFCE;
+Comment=A graphical front end for installing, removing and updating packages
+Terminal=false
+Type=Application
+Categories=System;Settings;PackageManager;
+StartupNotify=false
+

--- a/share/applications/org.mageia.dnfdragora-localinstall-gtk.desktop
+++ b/share/applications/org.mageia.dnfdragora-localinstall-gtk.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=dnfdragora Package Installer
+GenericName=RPM Package Installer
+Icon=dnfdragora
+Exec=dnfdragora --gtk --install %F
+OnlyShowIn=Cinnamon;GNOME;LXDE;MATE;ROX;XFCE;
+Comment=Install local packages on the system
+Terminal=false
+Type=Application
+Categories=System;Settings;PackageManager;
+StartupNotify=true
+NoDisplay=true
+MimeType=application/x-rpm;application/x-redhat-package-manager;
+
+

--- a/share/applications/org.mageia.dnfdragora-localinstall-qt.desktop
+++ b/share/applications/org.mageia.dnfdragora-localinstall-qt.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=dnfdragora Package Installer
+GenericName=RPM Package Installer
+Icon=dnfdragora
+Exec=dnfdragora --qt --install %F
+OnlyShowIn=KDE;LXQt;
+Comment=Install local packages on the system
+Terminal=false
+Type=Application
+Categories=System;Settings;PackageManager;
+StartupNotify=true
+NoDisplay=true
+MimeType=application/x-rpm;application/x-redhat-package-manager;
+
+

--- a/share/applications/org.mageia.dnfdragora-localinstall.desktop
+++ b/share/applications/org.mageia.dnfdragora-localinstall.desktop
@@ -3,6 +3,7 @@ Name=dnfdragora Package Installer
 GenericName=RPM Package Installer
 Icon=dnfdragora
 Exec=dnfdragora --install %F
+NotShowIn=Cinnamon;GNOME;KDE;LXDE;LXQt;MATE;ROX;XFCE;
 Comment=Install local packages on the system
 Terminal=false
 Type=Application

--- a/share/applications/org.mageia.dnfdragora-qt.desktop
+++ b/share/applications/org.mageia.dnfdragora-qt.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=dnfdragora
+GenericName=Install & Remove Software
+Icon=dnfdragora
+Exec=dnfdragora --qt
+OnlyShowIn=KDE;LXQt;
+Comment=A graphical front end for installing, removing and updating packages
+Terminal=false
+Type=Application
+Categories=System;Settings;PackageManager;
+StartupNotify=false
+

--- a/share/applications/org.mageia.dnfdragora.desktop
+++ b/share/applications/org.mageia.dnfdragora.desktop
@@ -3,6 +3,7 @@ Name=dnfdragora
 GenericName=Install & Remove Software
 Icon=dnfdragora
 Exec=dnfdragora
+NotShowIn=Cinnamon;GNOME;KDE;LXDE;LXQt;MATE;ROX;XFCE;
 Comment=A graphical front end for installing, removing and updating packages
 Terminal=false
 Type=Application


### PR DESCRIPTION
dnfdragora can be started with --qt to force Qt GUI, --gtk etc.. To ensure that we always have the native toolkit of the currently running desktop, I created additional .desktop files with OnlyShowIn conditions and the options --qt etc. in Exec.