### PR TITLE
Avoid generating multiple notifications.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,7 @@ Angelo Naselli <anaselli@linux.it>
 Neal Gompa     <ngompa13@gmail.com>
 Matteo Pasotti <matteo.pasotti@gmail.com>
 Björn Esser    <besser82@fedoraproject.org>
+
+Contributors:
+-------------
+Corey Farrell  <git@cfware.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ if(CHECK_RUNTIME_DEPENDENCIES)
 
 	# Find yaml module
 	find_python_module(yaml REQUIRED)
+
+	# Find notify2 module
+	find_python_module(notify2 REQUIRED)
 endif(CHECK_RUNTIME_DEPENDENCIES)
 
 option(ENABLE_COMPS "Use comps data for organizing packages?" OFF)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Example with ncurses:
 ### DNF Daemon
 * https://github.com/manatools/dnfdaemon/
 
+### notify2
+* https://bitbucket.org/takluyver/pynotify2/
+
 ### SUSE libyui
 * https://github.com/libyui/libyui
 * Consider to check some not yet approved changes here https://github.com/anaselli/libyui

--- a/dnfdragora/updater.py
+++ b/dnfdragora/updater.py
@@ -16,13 +16,16 @@ from PIL import Image
 from dnfdragora import config, misc, dialogs, ui
 from pystray import Menu, MenuItem
 from pystray import Icon as Tray
+import notify2
+
+notify2.init('dnfdragora-updater')
 
 
 class Updater:
 
     def __init__(self, options={}):
         self.__main_gui  = None
-        self.__notifier  = sh.Command("/usr/bin/notify-send")
+        self.__notifier  = notify2.Notification('dnfdragora', '', 'dnfdragora')
         self.__running   = True
         self.__updater   = threading.Thread(target=self.__update_loop)
         self.__scheduler = sched.scheduler(time.time, time.sleep)
@@ -166,15 +169,16 @@ class Updater:
                 time.sleep(0.5)
                 self.__backend = None
                 if (self.__update_count >= 1) or forced:
-                    self.__notifier(
-                        '-a', 'dnfdragora-updater',
-                        '-i', 'dnfdragora',
-                        '-u', 'normal',
+                    self.__notifier.update(
                         'dnfdragora',
-                        _('%d updates available.') % self.__update_count
+                        _('%d updates available.') % self.__update_count,
+                        'dnfdragora'
                     )
+                    self.__notifier.show()
                     self.__tray.icon = self.__icon
                     self.__tray.visible = True
+                else:
+                    self.__notifier.close()
             else:
                 print("DNF backend already locked cannot check for updates")
                 self.__update_count = -1


### PR DESCRIPTION
I've tested this on my workstation.  Ran the new `dnfdragora-updates`, it showed 106 updates.  Without clearing the notification I ran `sudo dnf update -y vim\*` which updated those 4 packages.  3 hours later the notification updated itself to say '102 updates available.'.  Then I ran `sudo dnf update -y` to update the remaining packages.  At the next 3 hours update check dnfdragora-updates removed the notification.