### PR TITLE
Handle additional DNF 3 progress callback actions

### DIFF
--- a/dnfdragora/const.py
+++ b/dnfdragora/const.py
@@ -134,12 +134,16 @@ TRANSACTION_RESULT_TYPES = {
 
 RPM_ACTIONS = {
     'update': _("Updating: %s"),
+    'updated': _("Updated: %s"),
     'install': _("Installing: %s"),
     'reinstall': _("Reinstalling: %s"),
+    'reinstalled': _("Reinstalled: %s"),
     'cleanup': _("Cleanup: %s"),
     'erase': _("Removing: %s"),
     'obsolete': _("Obsoleting: %s"),
+    'obsoleted': _("Obsoleted: %s"),
     'downgrade': _("Downgrading: %s"),
+    'downgraded': _("Downgraded: %s"),
     'verify': _("Verifying: %s"),
     'scriptlet': _("Running scriptlet: %s"),
     'preptrans': _("Preparing transaction: %s"),

--- a/dnfdragora/dnf_backend.py
+++ b/dnfdragora/dnf_backend.py
@@ -220,7 +220,10 @@ class DnfRootBackend(dnfdragora.backend.Backend, dnfdaemon.client.Client):
             #let's log once
             logger.debug('on_RPMProgress : [%s]', package)
             #print (const.RPM_ACTIONS[action] % name)
-            self.frontend.infobar.info_sub(const.RPM_ACTIONS[action] % name)
+            try:
+                self.frontend.infobar.info_sub(const.RPM_ACTIONS[action] % name)
+            except KeyError:
+                logger.debug('on_RPMProgress: unknown action %s', action)
         self._package_name = name
         if ts_current > 0 and ts_current <= ts_total:
             frac = float(ts_current) / float(ts_total)


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1624652 and
https://bugzilla.redhat.com/show_bug.cgi?id=1630113 . It seems
that DNF 3 sends out additional 'actions' in transaction
callbacks, without including them in the callback API or docs.
Along with a companion commit to dnfdaemon, this handles them.
This commit adds the new actions to const.RPM_ACTIONS so that
the on_RPMProgress dbus message handler can deal with them. It
also makes on_RPMProgress just log a debug message and continue
when a message has an unexpected action, rather than crashing.

Signed-off-by: Adam Williamson <awilliam@redhat.com>