### PR TITLE
set DefaultButton fix for gtkUI

### DIFF
--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -450,7 +450,7 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         icon_file = self.images_path + "find.png"
         self.find_button = self.factory.createIconButton(hbox_top, icon_file, _("&Search"))
         self.find_button.setWeight(0,6)
-        self.dialog.setDefaultButton(self.find_button)
+        self.find_button.setDefaultButton(True)
         self.find_entry.setKeyboardFocus()
 
         icon_file = self.images_path + "clear_22x22.png"

--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -226,6 +226,7 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         if sel_pkg :
             self._setInfoOnWidget(sel_pkg)
 
+        self.find_entry.setKeyboardFocus()
 
     def _configFileRead(self) :
         '''
@@ -451,7 +452,6 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         self.find_button = self.factory.createIconButton(hbox_top, icon_file, _("&Search"))
         self.find_button.setWeight(0,6)
         self.find_button.setDefaultButton(True)
-        self.find_entry.setKeyboardFocus()
 
         icon_file = self.images_path + "clear_22x22.png"
         self.reset_search_button = self.factory.createIconButton(hbox_top, icon_file, _("&Clear search"))


### PR DESCRIPTION
Hello everyone,
this seems to fix the issue for gtkUI, when pressing Enter in seachfield nothing happens
In qtUI setDefaultButton is working for dialog as fine as for button 
Tested in Fedora 25/28/29, but it really is a problem with libyui-gtk

Morizz