### PR TITLE
Add a workaround for issue 82

### DIFF
--- a/dnfdragora/updater.py
+++ b/dnfdragora/updater.py
@@ -54,13 +54,14 @@ class Updater:
             icon_path = icon_path + 'dnfdragora.png'
         else:
             icon_path = icon_path + '/dnfdragora.png'
-
+        issue_82_workaround_icon_path = icon_path
         try:
             from gi.repository import Gtk
             icon_theme = Gtk.IconTheme.get_default()
             icon_path  = icon_theme.lookup_icon("dnfdragora", 128, 0).get_filename()
+            issue_82_workaround_test = Image.open(icon_path) #Apperantly PIL (or Pillow?) doesn't support svg icons. If the filetype isn't supported an exception will be thrown
         except:
-            pass
+            icon_path = issue_82_workaround_icon_path # Use backup icon path.
 
         print("icon %s"%(icon_path))
         self.__icon  = Image.open(icon_path)


### PR DESCRIPTION
Just like the title suggests it's a workaround for issue #82.
If an unsupported icon file is detected a backup will be used.
I'm not a python programmer. so if i messed anything up let me know.