### PR TITLE
make notification balloons hide automatically in few seconds

### DIFF
--- a/dnfdragora/updater.py
+++ b/dnfdragora/updater.py
@@ -22,6 +22,20 @@ from queue import SimpleQueue, Empty
 import logging
 logger = logging.getLogger('dnfdragora.updater')
 
+
+class DnfdragoraUpdaterTray(Tray):
+    '''
+    pystray.Icon subclass with auto-closing notifications
+    '''
+    notification_expire_timeout = 7  # in seconds
+
+    def notify(self, *args, **kw):
+        super().notify(*args, **kw)
+        logger.debug('Scheduling notification expiration in {} seconds'.format(self.notification_expire_timeout))
+        # XXX: is this thread-safe?
+        threading.Timer(self.notification_expire_timeout, self.remove_notification).start()
+
+
 class Updater:
 
     def __init__(self, options={}):
@@ -138,7 +152,7 @@ class Updater:
             MenuItem(_('Exit'), self.__shutdown)
         )
         self.__name  = 'dnfdragora-updater'
-        self.__tray  = Tray(self.__name, icon=self.__icon, title=self.__name, menu=self.__menu)
+        self.__tray  = DnfdragoraUpdaterTray(self.__name, icon=self.__icon, title=self.__name, menu=self.__menu)
 
 
     def __get_theme_icon_pathname(self, name='dnfdragora'):


### PR DESCRIPTION
A possible fix for #178. Added a subclass of `pystray.Icon` with `.notify()` method overriden. It schedules a calling of `.remove_notification()` using `threading.Timer` right away after creating a notification request. Not sure if it is thread-safe, but it looks working.