### PR TITLE
Fix buttons hbox in Options dialog

### DIFF
--- a/dnfdragora/dialogs.py
+++ b/dnfdragora/dialogs.py
@@ -827,7 +827,7 @@ class OptionDialog(basedialog.BaseDialog):
     self.RestoreButton.setWeight(0,1)
 
     st = self.factory.createHStretch(hbox_bottom)
-    st.setWeight(0,4)
+    st.setWeight(0,1)
 
     self.quitButton = self.factory.createIconButton(hbox_bottom,"",_("&Close"))
     self.eventManager.addWidgetEvent(self.quitButton, self.onQuitEvent)


### PR DESCRIPTION
Fiddling locally with ui strings translation, I found that longer strings in "Restore defaults" button make the whole dialog window overstretch hotizontally. Here is a tiny fix for this.

Before:
![before](https://user-images.githubusercontent.com/795576/105496578-dc68f980-5ce7-11eb-9ab6-949565a765e5.png)

After:
![after](https://user-images.githubusercontent.com/795576/105496574-da9f3600-5ce7-11eb-8282-22864c052b37.png)


