### PR TITLE
Improve cache loading time at launch

### DIFF
--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -1379,7 +1379,11 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         """
         self.running = True
         while self.running == True:
-            event = self.dialog.waitForEvent(200)
+            loop_timeout = 20 if  self._status in (DNFDragoraStatus.CACHING_AVAILABLE, \
+                    DNFDragoraStatus.CACHING_UPDATE, \
+                    DNFDragoraStatus.CACHING_INSTALLED) \
+                    else 200
+            event = self.dialog.waitForEvent(loop_timeout)
 
             eventType = event.eventType()
 


### PR DESCRIPTION
When loading cache, time is lost in yui Event loop, instead of giving priority to heavy CPU consumming threads. In these cases, the change commute to a lower timeout, which can improve the loading time dividing it by 5.
If we load cache outside a thread, the UI becomes unresponsive.