### PR TITLE
Don't ask to reload metadata if dnf-makecache is enabled.

### DIFF
--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -28,6 +28,7 @@ from gi.repository import GLib
 import dnfdaemon.client
 
 import manatools.ui.helpdialog as helpdialog
+import manatools.services
 import dnfdragora.basedragora
 import dnfdragora.compsicons as compsicons
 import dnfdragora.groupicons as groupicons
@@ -1745,6 +1746,10 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
     def _check_MD_cache_expired(self):
       ''' Check metadata expired '''
       # check if MD cache management is disabled
+      ms = manatools.services()
+      if ms.GetUnitFileState('dnf-makecache.timer') == 'enabled' :
+          logger.debug("MakeCache enabled")
+          return False
       if self.md_update_interval <= 0:
         return False
       # check this is the first time dnfdragora is run for this user


### PR DESCRIPTION
If user thinks that metadata are expired, he can reload them through File menu.
This will avoid to start dnfdragora spending lot of time at launch.