### PR TITLE
Consumes the list of package of a transaction with distinction in to …

### DIFF
--- a/dnfdragora/dialogs.py
+++ b/dnfdragora/dialogs.py
@@ -397,7 +397,7 @@ class TransactionResult:
                 level2Item.this.own(False)
 
                 # packages that need to be downloaded
-                if sub in ['install', 'update', 'install-deps',
+                if sub in ['install', 'update', 'install-deps', 'install_weak',
                            'update-deps', 'obsoletes']:
                     total_size += size
                 for r in replaces:


### PR DESCRIPTION
…install packages: normal dependencies and weak dependencies

Thus, the weak dependencies can be displayed separately (see issue #185). An entry 'install_weak' is provided by dnfdaemon, according to another pull request.