### PR TITLE
Strip leading/trailing spaces from the search string

### DIFF
--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -1254,7 +1254,7 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
           self.use_regexp.setChecked(False)
           self.use_regexp.setEnabled(False)
 
-        search_string = self.find_entry.value()
+        search_string = self.find_entry.value().strip()
         if not search_string :
           return False
 


### PR DESCRIPTION
When search string starts with a space the search hangs for a long time.