### PR TITLE
Add info window and fixed segfault

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Contributors:
 -------------
 Corey Farrell   <git@cfware.com>
 Yuri Chornoivan <yurchor@ukr.net>
+Petr Leliaev    <petrleliaev@gmail.com>

--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -1099,7 +1099,7 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         self.info.setValue("")
         if pkg :
             missing = _("Missing information")
-            description = escape(pkg.description).replace("\n", "<br>")
+            description = escape(pkg.description).replace("\n", "<br>") if pkg.description else ''
             s = "<h2> %s - %s </h2>%s" %(pkg.name, pkg.summary, description)
             s += "<br>"
             if pkg.is_update :


### PR DESCRIPTION
There was no information after finishing packages install. Users asked to add an info window at the end of the transaction, so it was added.
There also appeared Segfault error while users were trying to find package with no description. The problem was fixed with the output of an empty line instead of a package description.