### PR TITLE
CI: Add missing build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,10 @@ jobs:
     steps:
       - run: dnf --assumeyes install
               /usr/bin/cmake
+              /usr/bin/msgmerge
+              /usr/bin/msgfmt
               /usr/bin/python3
+              /usr/bin/sphinx-build-3
               python3-yui
               python3-manatools
               python3-setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
 
     strategy:
       matrix:
-        build-type: ['normal']
         container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'


### PR DESCRIPTION
We need gettext and sphinx for translations and documentation, respectively.