### PR TITLE
Fix removesuffix problem

### DIFF
--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -764,7 +764,7 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
         sizePadded = pkg_sizeM
         # strip trailing K
         if sizePadded.endswith('K'):
-            sizePadded = sizePadded.removesuffix('K')
+            sizePadded = sizePadded[:-1]
         else:
             logger.warning('while building sizePadded, no trailing K in %s , why? proceeding anyways', pkg_sizeM)
         (sizeInt, decMark, decimals) = sizePadded.partition('.')


### PR DESCRIPTION
Hello, 
there was a problem with dnfdragora crushing when the python version in the system is 3.8 and below - removesuffix method appears in version 3.9. Using slice instead of removesuffix solves this problem.