### PR TITLE
Modernize the metainfo file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora-updat
 
 # Installing data files
 if(GETTEXT_FOUND)
-	install(FILES ${CMAKE_BINARY_DIR}/share/metainfo/org.mageia.dnfdragora.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/appdata)
+	install(FILES ${CMAKE_BINARY_DIR}/share/metainfo/org.mageia.dnfdragora.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 else()
-	install(FILES ${CMAKE_SOURCE_DIR}/share/metainfo/org.mageia.dnfdragora.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/appdata)
+	install(FILES ${CMAKE_SOURCE_DIR}/share/metainfo/org.mageia.dnfdragora.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 endif(GETTEXT_FOUND)
 
 install(FILES ${CMAKE_SOURCE_DIR}/share/applications/org.mageia.dnfdragora.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Find all translation-files
 file(GLOB PO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.po")
 
-# Set our target for AppData file
-set(xml_file ${CMAKE_BINARY_DIR}/share/metainfo/org.mageia.dnfdragora.appdata.xml)
-# Merge the translations into the initial AppData file
+# Set our target for AppStream file
+set(xml_file ${CMAKE_BINARY_DIR}/share/metainfo/org.mageia.dnfdragora.metainfo.xml)
+# Merge the translations into the initial AppStream file
 add_custom_command(OUTPUT ${xml_file}
-        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --xml -d ${CMAKE_CURRENT_SOURCE_DIR} --template ${CMAKE_SOURCE_DIR}/share/metainfo/org.mageia.dnfdragora.appdata.xml -o ${xml_file}
+        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --xml -d ${CMAKE_CURRENT_SOURCE_DIR} --template ${CMAKE_SOURCE_DIR}/share/metainfo/org.mageia.dnfdragora.metainfo.xml -o ${xml_file}
         COMMENT "Generating ${xml_file}"
         )
 add_custom_target(make_directory_for_xml ALL

--- a/share/metainfo/org.mageia.dnfdragora.appdata.xml
+++ b/share/metainfo/org.mageia.dnfdragora.appdata.xml
@@ -1,28 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2016 Neal Gompa <ngompa13@gmail.com> -->
-<component type="desktop">
- <id>org.mageia.dnfdragora.desktop</id>
- <metadata_license>CC-BY-SA-4.0</metadata_license>
- <project_license>GPL-3.0</project_license>
- <name>dnfdragora</name>
- <summary>A frontend for DNF using libyui UI abstraction library</summary>
- <description>
-  <p>
-     dnfdragora is a DNF frontend, inspired by rpmdragora from Mageia (originally rpmdrake).
-  </p>
+<component type="desktop-application">
+  <id>org.mageia.dnfdragora</id>
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>dnfdragora</name>
+  <developer id="org.mageia">
+    <name>ManaTools</name>
+  </developer>
+  <summary>A frontend for DNF using libyui UI abstraction library</summary>
+  <description>
+    <p>
+      dnfdragora is a DNF frontend, inspired by rpmdragora from Mageia (originally rpmdrake).
+    </p>
 
-  <p>
-     dnfdragora is written in Python 3 and uses libYui, the widget abstraction library written by SUSE,
-     so that it can be run using Qt 5, GTK+ 3, or ncurses interfaces. It provides a frontend for the
-     DNF package manager that can be used in any kind of system environment.
-  </p>
- </description>
- <screenshots>
-   <screenshot type="default" width="1706" height="862">
-       https://raw.githubusercontent.com/manatools/dnfdragora/master/screenshots/dnfdragora-qt.png
-   </screenshot>
- </screenshots>
- <url type="homepage">https://github.com/manatools/dnfdragora</url>
- <update_contact>ngompa_at_mageia.org</update_contact>
+    <p>
+      dnfdragora is written in Python 3 and uses libYui, the widget abstraction library written by SUSE,
+      so that it can be run using Qt 5, GTK+ 3, or ncurses interfaces. It provides a frontend for the
+      DNF package manager that can be used in any kind of system environment.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/manatools/dnfdragora/master/screenshots/dnfdragora-qt.png</image>
+      <caption>Main window</caption>
+    </screenshot>
+  </screenshots>
+  <url type="bugtracker">https://github.com/manatools/dnfdragora/issues</url>
+  <url type="homepage">https://github.com/manatools/dnfdragora</url>
+  <content_rating type="oars-1.1"/>
+  <launchable type="desktop-id">org.mageia.dnfdragora.desktop</launchable>
+  <update_contact>ngompa_at_mageia.org</update_contact>
 </component>
-

--- a/tools/po-update.sh
+++ b/tools/po-update.sh
@@ -31,7 +31,7 @@ POT_FILE="$POT_DIR/$DOMAIN.pot"
 /usr/bin/xgettext \
 	-j \
 	--output="$POT_FILE" \
-	share/metainfo/org.mageia.dnfdragora.appdata.xml
+	share/metainfo/org.mageia.dnfdragora.metainfo.xml
 /bin/sed --in-place --expression="s/charset=CHARSET/charset=UTF-8/" "$POT_FILE"
 
 update_po() {


### PR DESCRIPTION
- Fix component type
- Remove deprecated .desktop suffix from app id
- Add developer tag
- Add launchable tag
- Add OARS metadata
- Remove hardcoded screenshot dimensions
- Add missing image tag and screenshot caption
- Add bugtracker url
- Improve formatting
- Use correct suffix and install path for AppStream metadata

Before: 
```
$ appstreamcli validate org.mageia.dnfdragora.appdata.xml
E: org.mageia.dnfdragora.desktop:21: screenshot-no-media
I: org.mageia.dnfdragora.desktop:~: desktop-app-launchable-omitted
I: org.mageia.dnfdragora.desktop:~: content-rating-missing
I: org.mageia.dnfdragora.desktop:~: developer-info-missing

✘ Validation failed: errors: 1, infos: 3, pedantic: 2
```

After:
```
$ appstreamcli validate org.mageia.dnfdragora.appdata.xml

✔ Validation was successful: pedantic: 1
```

/cc @Conan-Kudo