### PR TITLE
Add --remove command-line option

### DIFF
--- a/bin/dnfdragora
+++ b/bin/dnfdragora
@@ -37,6 +37,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--install',     nargs='+', help=_('install packages'))
     parser.add_argument('--show',        nargs=1,   help=_('search for and show a package by name'))
+    parser.add_argument('--remove',      nargs='+', help=_('remove packages'))
     parser.add_argument('--update-only', help=_('show updates only dialog'), action='store_true')
     parser.add_argument('--version',     help=_('show application version and exit'), action='store_true')
     parser.add_argument('--exit',        help=_('force dnfdaemon dbus services used by dnfdragora to exit'), action='store_true')
@@ -73,6 +74,8 @@ if __name__ == "__main__":
         options['install'] = args.install
     if args.show:
         options['show'] = args.show[0]
+    if args.remove:
+        options['remove'] = args.remove
     if args.exit :
         misc.dbus_dnfsystem('Exit')
     elif args.version:

--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -3018,6 +3018,13 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
                   self._updateSearchState()
                   self._searchPackages()
 
+                if not self._runtime_option_managed and 'remove' in self.options.keys() :
+                  pkgs = " ".join(self.options['remove'])
+                  self.backend.Remove(pkgs, sync=True)
+                  self.backend.BuildTransaction()
+                  self._runtime_option_managed = True
+                  return
+
                 self._enableAction(True)
                 filter = self._filterNameSelected()
                 self.checkAllUpdateButton.setEnabled(filter == 'to_update')


### PR DESCRIPTION
This MR adds support for a new `--remove` command-line option.

Previously, dnfdragora supported starting a package installation directly through `--install`, but there was no equivalent option for package removal. This change adds `--remove` handling in the command-line parser and processes it during UI startup.

When `--remove` is provided, the requested package names are passed to the backend removal method and a transaction is built automatically.

This makes it possible to launch dnfdragora directly for package removal, similar to the existing install workflow.