### PR TITLE
Add --show command-line option

### DIFF
--- a/bin/dnfdragora
+++ b/bin/dnfdragora
@@ -36,6 +36,7 @@ if __name__ == "__main__":
     parser.add_argument('--locales-dir', nargs='?', help=_('directory containing localization strings (developer only)'))
 
     parser.add_argument('--install',     nargs='+', help=_('install packages'))
+    parser.add_argument('--show',        nargs=1,   help=_('search for and show a package by name'))
     parser.add_argument('--update-only', help=_('show updates only dialog'), action='store_true')
     parser.add_argument('--version',     help=_('show application version and exit'), action='store_true')
     parser.add_argument('--exit',        help=_('force dnfdaemon dbus services used by dnfdragora to exit'), action='store_true')
@@ -70,6 +71,8 @@ if __name__ == "__main__":
         options['images_path'] = args.images_path
     if args.install:
         options['install'] = args.install
+    if args.show:
+        options['show'] = args.show[0]
     if args.exit :
         misc.dbus_dnfsystem('Exit')
     elif args.version:

--- a/dnfdragora/ui.py
+++ b/dnfdragora/ui.py
@@ -3009,6 +3009,14 @@ class mainGui(dnfdragora.basedragora.BaseDragora):
                   self._runtime_option_managed = True
                   return
 
+                if not self._runtime_option_managed and 'show' in self.options.keys() :
+                  self._search_text = self.options['show']
+                  self._search_nevra = True
+                  self._search_scope = 'all'
+                  self._runtime_option_managed = True
+                  self._updateSearchState()
+                  self._searchPackages()
+
                 self._enableAction(True)
                 filter = self._filterNameSelected()
                 self.checkAllUpdateButton.setEnabled(filter == 'to_update')


### PR DESCRIPTION
This MR adds support for a new `--show <package>` command-line option.

The option allows dnfdragora to be started with an initial package search. The package name is passed from the command-line parser to the UI through runtime options.

Example usage:

```bash
dnfdragora --show firefox